### PR TITLE
Update dependencies pulled from source

### DIFF
--- a/dependencies/SDL2/CMakeLists.txt
+++ b/dependencies/SDL2/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_definitions(SDL_THREAD_GENERIC_COND_SUFFIX)
 
 FetchContent_Declare(SDL2
     GIT_REPOSITORY https://github.com/libsdl-org/SDL
-    GIT_TAG release-2.26.2
+    GIT_TAG release-2.26.3
 )
 
 FetchContent_MakeAvailable(SDL2)

--- a/dependencies/SDL2_image/CMakeLists.txt
+++ b/dependencies/SDL2_image/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SDL2IMAGE_INSTALL OFF)
 
 FetchContent_Declare(sdl_image
     GIT_REPOSITORY https://github.com/libsdl-org/SDL_image
-    GIT_TAG release-2.6.2
+    GIT_TAG release-2.6.3
 )
 
 FetchContent_MakeAvailable(sdl_image)

--- a/dependencies/freetype/CMakeLists.txt
+++ b/dependencies/freetype/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SKIP_INSTALL_ALL ON)
 FetchContent_Declare(
   freetype
   GIT_REPOSITORY https://gitlab.freedesktop.org/freetype/freetype.git
-  GIT_TAG        VER-2-12-1
+  GIT_TAG        VER-2-13-0
 )
 
 FetchContent_MakeAvailable(freetype)


### PR DESCRIPTION
SDL2 to 2.26.3, release notes: https://github.com/libsdl-org/SDL/releases/tag/release-2.26.3
SDL_image to 2.6.3, release notes: https://github.com/libsdl-org/SDL_image/releases/tag/release-2.6.3
Freetype to 2.13.0, release notes: https://sourceforge.net/projects/freetype/files/freetype2/2.13.0/

SDL releases are bugfixes, no impact
Freetype adds support for new variable font format

Compiled and play tested on Windows