### PR TITLE
Ignore ninja build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _deps
 .vs
 .vscode
 /tmp
+*.ninja*


### PR DESCRIPTION
I use `ninja` CMake generator for Linux builds
https://ninja-build.org/

Files generated by ninja build system:
* `.ninja_log`
* `.ninja_deps`
* `build.ninja`