### PR TITLE
Upgrade SDL2 vendored version

### DIFF
--- a/dependencies/SDL2/CMakeLists.txt
+++ b/dependencies/SDL2/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_definitions(SDL_THREAD_GENERIC_COND_SUFFIX)
 
 FetchContent_Declare(SDL2
     GIT_REPOSITORY https://github.com/libsdl-org/SDL
-    GIT_TAG release-2.26.3
+    GIT_TAG release-2.26.4
 )
 
 FetchContent_MakeAvailable(SDL2)


### PR DESCRIPTION
This is a bugfix release, so IMO should be included

Release notes: https://github.com/libsdl-org/SDL/releases/tag/release-2.26.4