### PR TITLE
Upgrade Windows dependencies

### DIFF
--- a/dependencies/SDL2/CMakeLists.txt
+++ b/dependencies/SDL2/CMakeLists.txt
@@ -3,9 +3,9 @@ MESSAGE( STATUS "Fetching SDL2..." )
 SET( SDL_PTHREADS ON )
 ADD_COMPILE_DEFINITIONS( SDL_THREAD_GENERIC_COND_SUFFIX )
 
-FETCHCONTENT_DECLARE( SDL2
-	GIT_REPOSITORY https://github.com/libsdl-org/SDL
-	GIT_TAG release-2.26.5
-	)
+FetchContent_Declare(SDL2
+    GIT_REPOSITORY https://github.com/libsdl-org/SDL
+    GIT_TAG release-2.28.3
+)
 
 FETCHCONTENT_MAKEAVAILABLE( SDL2 )

--- a/dependencies/freetype/CMakeLists.txt
+++ b/dependencies/freetype/CMakeLists.txt
@@ -7,10 +7,10 @@ SET( FT_DISABLE_HARFBUZZ ON )
 SET( FT_DISABLE_BROTLI ON )
 SET( SKIP_INSTALL_ALL ON )
 
-FETCHCONTENT_DECLARE(
-	freetype
-	GIT_REPOSITORY https://gitlab.freedesktop.org/freetype/freetype.git
-	GIT_TAG VER-2-13-0
+FetchContent_Declare(
+  freetype
+  GIT_REPOSITORY https://gitlab.freedesktop.org/freetype/freetype.git
+  GIT_TAG        VER-2-13-2
 )
 
 FETCHCONTENT_MAKEAVAILABLE( freetype )


### PR DESCRIPTION
SDL2 2.26.5 -> 2.28.3
Release notes:
https://github.com/libsdl-org/SDL/releases/tag/release-2.28.0
https://github.com/libsdl-org/SDL/releases/tag/release-2.28.3

freetype 2.13.0 -> 2.13.2
Release notes:
https://sourceforge.net/projects/freetype/files/freetype2/2.13.2/