### PR TITLE
CMake: Run glsmac_version command in source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ ADD_CUSTOM_TARGET( glsmac_version )
 IF ( NOT WIN32 )
 	ADD_CUSTOM_COMMAND(
 		TARGET glsmac_version PRE_BUILD
+		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		COMMAND git show -s --format='\#define GLSMAC_LAST_COMMIT \"%h\"' > ${PROJECT_SOURCE_DIR}/src/tmp/last_commit.h
 		DEPENDS .git/COMMIT_EDITMSG
 	)


### PR DESCRIPTION
This needs to be done for when the build directory isn't in a subdirectory.
