### PR TITLE
Name font file relative to source directory, not current (build) directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ SET( CMAKE_CXX_FLAGS " -std=c++17 ${CMAKE_CXX_FLAGS} -Wno-pointer-arith -Wno-vla
 ADD_SUBDIRECTORY( tools )
 SET( EMBED_CPP "src/tmp/embed.cpp" )
 SET( EMBED_FILES
-	"./resource/font/terminus/TerminusTTF-4.49.3-minified.ttf"
+	"${PROJECT_SOURCE_DIR}/resource/font/terminus/TerminusTTF-4.49.3-minified.ttf"
 )
 ADD_CUSTOM_COMMAND(
 	OUTPUT ${EMBED_CPP}


### PR DESCRIPTION
When using an out-of-source build, the `embedder` step fails, because the font file is specified with a path relative to `.`, which in this case is the build directory.

This patch changes the specification to be relative to `${PROJECT_SOURCE_DIR}`, which finds the font file even when building out of source.