### PR TITLE
fix: windows macro issue

### DIFF
--- a/src/env/Win32.h
+++ b/src/env/Win32.h
@@ -33,4 +33,7 @@ typedef long long ptr_int_t;
 #undef ERROR
 #undef CALLBACK
 
+// even more collisions
+#undef MB_RIGHT
+
 #endif

--- a/src/input/Types.h
+++ b/src/input/Types.h
@@ -1,6 +1,6 @@
 #pragma once
+
 #include <cstdint>
-#undef MB_RIGHT
 
 namespace input {
 

--- a/src/input/Types.h
+++ b/src/input/Types.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstdint>
+#undef MB_RIGHT
 
 namespace input {
 


### PR DESCRIPTION
Yes, there is a MB_RIGHT macro definition that shadowed mouse_button_t::MB_RIGHT. Windows specific (of course) in WinUser.h