### PR TITLE
fix: remaining build issues

### DIFF
--- a/src/GLSMAC.h
+++ b/src/GLSMAC.h
@@ -14,7 +14,7 @@ namespace ui {
 class UI;
 }
 
-namespace task::main {
+namespace task::principal {
 class Main;
 }
 
@@ -35,7 +35,7 @@ private:
 	ui::UI* m_ui = nullptr;
 
 private:
-	friend class task::main::Main;
+	friend class task::principal::Main;
 	void RunMain();
 
 private:

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <unordered_map>
 #include <atomic>
+#include <string>
 
 // TODO: move to config
 extern const size_t g_max_fps;

--- a/src/input/Event.h
+++ b/src/input/Event.h
@@ -12,10 +12,10 @@ public:
 
 	typedef union {
 		struct {
-			ssize_t x;
-			ssize_t y;
+			ptrdiff_t x;
+			ptrdiff_t y;
 			mouse_button_t button;
-			ssize_t scroll_y;
+			ptrdiff_t scroll_y;
 		} mouse;
 		struct {
 			bool is_printable;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,7 +289,7 @@ int main( const int argc, const char* argv[] ) {
 		}
 
 		if ( newui ) {
-			NEW( task, task::main::Main );
+			NEW( task, task::principal::Main );
 		}
 		else if ( config.HasLaunchFlag( config::Config::LF_QUICKSTART ) ) {
 			NEWV( state, game::backend::State ); // TODO: initialize settings randomly

--- a/src/task/main/Main.cpp
+++ b/src/task/main/Main.cpp
@@ -3,7 +3,7 @@
 #include "GLSMAC.h"
 
 namespace task {
-namespace main {
+namespace principal {
 
 void Main::Start() {
 

--- a/src/task/main/Main.h
+++ b/src/task/main/Main.h
@@ -7,7 +7,7 @@
 class GLSMAC;
 
 namespace task {
-namespace main {
+namespace principal {
 
 CLASS( Main, common::Task )
 	void Start() override;

--- a/src/ui/geometry/Geometry.cpp
+++ b/src/ui/geometry/Geometry.cpp
@@ -161,7 +161,7 @@ void Geometry::RemoveHandler( const geometry_handler_id_t id ) {
 	m_handler_types.erase( id );
 }
 
-const bool Geometry::Contains( const types::Vec2< ssize_t >& position ) const {
+const bool Geometry::Contains( const types::Vec2< ptrdiff_t >& position ) const {
 	return
 		position.x > m_effective_area.left &&
 			position.y > m_effective_area.top &&

--- a/src/ui/geometry/Geometry.h
+++ b/src/ui/geometry/Geometry.h
@@ -115,7 +115,7 @@ public:
 	const geometry_handler_id_t AddHandler( const geometry_handler_type_t type, const std::function< void() >& f );
 	void RemoveHandler( const geometry_handler_id_t id );
 
-	const bool Contains( const types::Vec2< ssize_t >& position ) const;
+	const bool Contains( const types::Vec2< ptrdiff_t >& position ) const;
 
 protected:
 


### PR DESCRIPTION
Missing header when working with visual studio

Replaced ssize_t with ptrdiff_t. I might have fixed this one by attempting to include other headers to make sure ssize_t is defined but if though it's less impactful to use ptrdiff_t there

renamed the namespace task::main to task::principal (maybe the name sucks...) to avoid the compiler screwing up but confusing this namespace with the main function