### PR TITLE
Fix glew linking on Windows

### DIFF
--- a/dependencies/glew/CMakeLists.txt
+++ b/dependencies/glew/CMakeLists.txt
@@ -8,7 +8,7 @@ INCLUDE( FetchContent )
 FETCHCONTENT_DECLARE(
 	glew
 	GIT_REPOSITORY https://github.com/Perlmint/glew-cmake.git
-	GIT_TAG glew-cmake-2.3.1
+	GIT_TAG glew-cmake-2.2.0-1
 )
 
 FETCHCONTENT_GETPROPERTIES( glew )


### PR DESCRIPTION
Downgrades the `glew` version, since 2.3.1 fails to link on Windows with the following error:

```
  FAILED: _deps/glew-build/bin/glew-shared.dll _deps/glew-build/lib/glew-shared.lib 
  C:\WINDOWS\system32\cmd.exe /C "cd . && C:\PROGRA~1\MICROS~2\18\Community\VC\Tools\Llvm\x64\bin\clang.exe -nostartfiles -nostdlib --target=amd64-pc-windows-msvc -fdiagnostics-absolute-paths -O3 -DNDEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrt  -shared -fuse-ld=lld-link -o _deps\glew-build\bin\glew-shared.dll  -Xlinker /MANIFEST:EMBED -Xlinker /implib:_deps\glew-build\lib\glew-shared.lib -Xlinker /pdb:_deps\glew-build\bin\glew-shared.pdb -Xlinker /version:2.3 _deps/glew-build/CMakeFiles/libglew_shared.dir/src/glew.c.obj  -lopengl32.lib  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -loldnames  && cd ."
C:\src\glsmac-clone\out\build\x64-release-win-clang\lld-link : error : undefined symbol: memset
  
  >>> referenced by _deps/glew-build/CMakeFiles/libglew_shared.dir/src/glew.c.obj:(glewContextInit)
```