### PR TITLE
Build fix for Arch Linux, GCC 16.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ ENDIF ()
 IF ( NOT WIN32 )
 	SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
 ENDIF ()
-SET( CMAKE_CXX_FLAGS " -std=c++17 ${CMAKE_CXX_FLAGS} -Wno-pointer-arith -Wno-vla-extension" )
+SET( CMAKE_CXX_FLAGS " -std=c++17 ${CMAKE_CXX_FLAGS} -Wno-pointer-arith " )
 
 ADD_SUBDIRECTORY( tools )
 SET( EMBED_CPP "src/tmp/embed.cpp" )

--- a/src/game/backend/unit/Unit.h
+++ b/src/game/backend/unit/Unit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include <string>
 
 #include "gse/Wrappable.h"


### PR DESCRIPTION
Removes warning that is no longer available in GCC 16.